### PR TITLE
Make the value of SuggestionRow generic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+## OS X Finder
+.DS_Store
+
+## Build generated
+build/
+DerivedData
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+## Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+TokenRow/Example/Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+
+Carthage/
+Cartfile.resolved

--- a/SuggestionRow.xcodeproj/project.pbxproj
+++ b/SuggestionRow.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6A9D202F2BA6E4BFA39C5B05 /* Pods_SuggestionRowUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AB6675C27F04324EC0932A6 /* Pods_SuggestionRowUITests.framework */; };
+		8FA74BC91D831E2100571A0C /* String+SuggestionValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA74BC81D831E2100571A0C /* String+SuggestionValue.swift */; };
 		AA81DD461D64F706002F17F9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA81DD451D64F706002F17F9 /* AppDelegate.swift */; };
 		AA81DD481D64F707002F17F9 /* SuggestionExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA81DD471D64F707002F17F9 /* SuggestionExampleViewController.swift */; };
 		AA81DD4B1D64F707002F17F9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA81DD491D64F707002F17F9 /* Main.storyboard */; };
@@ -47,6 +48,7 @@
 		25FDE1B01589CAB993067AF8 /* Pods-SuggestionRowTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SuggestionRowTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SuggestionRowTests/Pods-SuggestionRowTests.debug.xcconfig"; sourceTree = "<group>"; };
 		68D0D0DDD51BB31798E20BFD /* Pods-SuggestionRow.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SuggestionRow.release.xcconfig"; path = "Pods/Target Support Files/Pods-SuggestionRow/Pods-SuggestionRow.release.xcconfig"; sourceTree = "<group>"; };
 		7CD7B18C2AB9C6EBA7388C89 /* Pods-SuggestionRowUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SuggestionRowUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SuggestionRowUITests/Pods-SuggestionRowUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		8FA74BC81D831E2100571A0C /* String+SuggestionValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SuggestionValue.swift"; sourceTree = "<group>"; };
 		92D8B188ED3E2B0E4F9C4557 /* Pods_SuggestionRowTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SuggestionRowTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9AB6675C27F04324EC0932A6 /* Pods_SuggestionRowUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SuggestionRowUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5F8E139F8EF16B60D1F1F4C /* Pods-SuggestionRow.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SuggestionRow.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SuggestionRow/Pods-SuggestionRow.debug.xcconfig"; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 				AA81DD771D64F824002F17F9 /* SuggestionCollectionViewCell.swift */,
 				AA81DD7C1D64FB78002F17F9 /* SuggestionTableCell.swift */,
 				AA81DD7D1D64FB78002F17F9 /* SuggestionTableViewCell.swift */,
+				8FA74BC81D831E2100571A0C /* String+SuggestionValue.swift */,
 			);
 			name = SuggestionRow;
 			sourceTree = "<group>";
@@ -460,6 +463,7 @@
 				AA81DD7E1D64FB78002F17F9 /* SuggestionTableCell.swift in Sources */,
 				AA81DD781D64F824002F17F9 /* SuggestionRow.swift in Sources */,
 				AA81DD461D64F706002F17F9 /* AppDelegate.swift in Sources */,
+				8FA74BC91D831E2100571A0C /* String+SuggestionValue.swift in Sources */,
 				AA81DD791D64F824002F17F9 /* SuggestionCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SuggestionRow/String+SuggestionValue.swift
+++ b/SuggestionRow/String+SuggestionValue.swift
@@ -1,0 +1,15 @@
+//
+//  String+SuggestionValue.swift
+//  SuggestionRow
+//
+//  Created by Mathias Claassen on 9/9/16.
+//  Copyright © 2016 Helene Martin. All rights reserved.
+//
+
+import Foundation
+
+extension String: SuggestionValue {
+    public var suggestionString: String {
+        return self
+    }
+}

--- a/SuggestionRow/SuggestionCell.swift
+++ b/SuggestionRow/SuggestionCell.swift
@@ -10,9 +10,9 @@ import UIKit
 import Eureka
 
 /// General suggestion cell. Create a subclass or use SuggestionCollectionCell or SuggestionTableCell.
-public class SuggestionCell: _FieldCell<String>, CellType {
+public class SuggestionCell<T: SuggestionValue>: _FieldCell<T>, CellType {
     let cellReuseIdentifier = "Eureka.SuggestionCellIdentifier"
-    var suggestions: [String]?
+    var suggestions: [T]?
     
     required public init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -30,13 +30,17 @@ public class SuggestionCell: _FieldCell<String>, CellType {
         formViewController()?.textInputDidBeginEditing(textField, cell: self)
         textField.selectAll(nil)
         
-        (row as? SuggestionRowProtocol)?.setSuggestions(textField.text!)
+        if let text = textField.text {
+            setSuggestions(text)
+        }
     }
     
     public override func textFieldDidChange(textField: UITextField) {
         super.textFieldDidChange(textField)
-        
-        (row as? SuggestionRowProtocol)?.setSuggestions(textField.text!)
+        if let text = textField.text {
+            setSuggestions(text)
+        }
+
     }
     
     public override func textFieldDidEndEditing(textField: UITextField) {
@@ -44,6 +48,8 @@ public class SuggestionCell: _FieldCell<String>, CellType {
         formViewController()?.textInputDidEndEditing(textField, cell: self)
         textField.text = row.displayValueFor?(row.value)
     }
+
+    func setSuggestions(string: String) {}
     
     func reload() {}
 }

--- a/SuggestionRow/SuggestionCollectionCell.swift
+++ b/SuggestionRow/SuggestionCollectionCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 let accessoryViewHeight = CGFloat(40)
 
-public class SuggestionCollectionCell<CollectionViewCell: UICollectionViewCell where CollectionViewCell: EurekaSuggestionCollectionViewCell>: SuggestionCell, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+public class SuggestionCollectionCell<T: SuggestionValue, CollectionViewCell: UICollectionViewCell where CollectionViewCell: EurekaSuggestionCollectionViewCell, CollectionViewCell.S == T>: SuggestionCell<T>, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     
     /// callback that can be used to customize the appearance of the UICollectionViewCell in the inputAccessoryView
     public var customizeCollectionViewCell: (CollectionViewCell -> Void)?
@@ -52,6 +52,11 @@ public class SuggestionCollectionCell<CollectionViewCell: UICollectionViewCell w
     override func reload() {
         collectionView?.reloadData()
     }
+
+    override func setSuggestions(string: String) {
+        suggestions = (row as? _SuggestionRow<T, SuggestionCollectionCell>)?.filterFunction(string)
+        reload()
+    }
     
     //MARK: UICollectionViewDelegate and Datasource
     public func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -61,7 +66,7 @@ public class SuggestionCollectionCell<CollectionViewCell: UICollectionViewCell w
     public func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCellWithReuseIdentifier(cellReuseIdentifier, forIndexPath: indexPath) as! CollectionViewCell
         if let suggestion = suggestions?[indexPath.row] {
-            cell.setText(suggestion)
+            cell.setupForValue(suggestion)
         }
         customizeCollectionViewCell?(cell)
         return cell
@@ -70,14 +75,14 @@ public class SuggestionCollectionCell<CollectionViewCell: UICollectionViewCell w
     public func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
         if let suggestion = suggestions?[indexPath.row] {
             row.value = suggestion
-            row.updateCell()
+            cellResignFirstResponder()
         }
     }
     
     public func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
         let cell = CollectionViewCell(frame: CGRectZero)
         if let suggestion = suggestions?[indexPath.row] {
-            cell.setText(suggestion)
+            cell.setupForValue(suggestion)
         }
         return cell.sizeThatFits()
     }

--- a/SuggestionRow/SuggestionCollectionViewCell.swift
+++ b/SuggestionRow/SuggestionCollectionViewCell.swift
@@ -10,13 +10,18 @@ import Eureka
 
 
 public protocol EurekaSuggestionCollectionViewCell {
-    func setText(prediction: String)
+    associatedtype S: SuggestionValue
+
+    func setupForValue(value: S)
     func sizeThatFits() -> CGSize
 }
 
 /// Default cell for the inputAccessoryView of the SuggestionRow
-public class SuggestionCollectionViewCell: UICollectionViewCell, EurekaSuggestionCollectionViewCell {
+public class SuggestionCollectionViewCell<T: SuggestionValue>: UICollectionViewCell, EurekaSuggestionCollectionViewCell {
+    public typealias S = T
+
     public var label = UILabel()
+
     override public init(frame: CGRect) {
         super.init(frame: frame)
         initialize()
@@ -44,8 +49,8 @@ public class SuggestionCollectionViewCell: UICollectionViewCell, EurekaSuggestio
         contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[label]|", options: [], metrics: nil, views: ["label": label]))
     }
     
-    public func setText(prediction: String) {
-        label.text = "  \(prediction)"
+    public func setupForValue(value: T) {
+        label.text = "  \(value.suggestionString)"
     }
     
     public func sizeThatFits() -> CGSize {

--- a/SuggestionRow/SuggestionExampleViewController.swift
+++ b/SuggestionRow/SuggestionExampleViewController.swift
@@ -12,9 +12,15 @@ class SuggestionExampleViewController: FormViewController {
         super.viewDidLoad()
         
         let options = ["Apple", "Appetizer", "Around", "Addiction", "Anachronism", "Ant", "Author"]
-        
+        let users: [Scientist] = [Scientist(id: 1, firstName: "Albert", lastName: "Einstein"),
+                             Scientist(id: 2, firstName: "Isaac", lastName: "Newton"),
+                             Scientist(id: 3, firstName: "Galileo", lastName: "Galilei"),
+                             Scientist(id: 4, firstName: "Marie", lastName: "Curie"),
+                             Scientist(id: 5, firstName: "Louis", lastName: "Pasteur"),
+                             Scientist(id: 6, firstName: "Michael", lastName: "Faraday")]
+
         form +++ Section("Input accessory view suggestions")
-            <<< SuggestionAccessoryRow() {
+            <<< SuggestionAccessoryRow<String>() {
                 $0.filterFunction = { text in
                     options.filter({ $0.hasPrefix(text) })
                 }
@@ -22,11 +28,37 @@ class SuggestionExampleViewController: FormViewController {
             }
         
         +++ Section("Table suggestions")
-            <<< SuggestionTableRow() {
+            <<< SuggestionTableRow<Scientist>() {
                 $0.filterFunction = { text in
-                    options.filter({ $0.hasPrefix(text) })
+                    users.filter({ $0.firstName.lowercaseString.containsString(text.lowercaseString) })
                 }
-                $0.placeholder = "Enter text that starts with A..."
+                $0.placeholder = "Search for a famous scientist"
             }
     }
+}
+
+
+struct Scientist: SuggestionValue {
+    var id: Int
+    var firstName: String
+    var lastName: String
+
+
+    var suggestionString: String {
+        return "\(firstName) \(lastName)"
+    }
+
+    init(id: Int, firstName: String, lastName: String) {
+        self.firstName = firstName
+        self.lastName = lastName
+        self.id = id
+    }
+
+    init?(string stringValue: String) {
+        return nil
+    }
+}
+
+func == (lhs: Scientist, rhs: Scientist) -> Bool {
+    return lhs.id == rhs.id
 }

--- a/SuggestionRow/SuggestionRow.swift
+++ b/SuggestionRow/SuggestionRow.swift
@@ -8,38 +8,34 @@
 import Foundation
 import Eureka
 
-protocol SuggestionRowProtocol {
-    var filterFunction: ((String) -> [String])! { get set }
-    func setSuggestions(text: String)
+public protocol SuggestionValue: Equatable, InputTypeInitiable {
+    var suggestionString: String { get }
 }
 
 /// Generic suggestion row superclass that defines how to get a list of suggestions based on user input.
-public class _SuggestionRow<Cell: SuggestionCell where Cell.Value == String>: FieldRow<String, Cell>, SuggestionRowProtocol {
-    var filterFunction: ((String) -> [String])!
+public class _SuggestionRow<T: SuggestionValue, Cell: BaseCell
+        where Cell: CellType, Cell: TextFieldCell, Cell: TypedCellType, Cell.Value == T>: FieldRow<T, Cell> {
+
+    public var filterFunction: ((String) -> [T])!
 
     required public init(tag: String?) {
         super.init(tag: tag)
 
         displayValueFor = { value in
-            return value
+            return value?.suggestionString
         }
-    }
-
-    func setSuggestions(text: String) {
-        self.cell.suggestions = filterFunction(text)
-        self.cell.reload()
     }
 }
 
 /// Row that lets the user choose a suggested option from a list shown in the inputAccessoryView.
-public final class SuggestionAccessoryRow: _SuggestionRow<SuggestionCollectionCell<SuggestionCollectionViewCell>>, RowType {
+public final class SuggestionAccessoryRow<T: SuggestionValue>: _SuggestionRow<T, SuggestionCollectionCell<T, SuggestionCollectionViewCell<T>>>, RowType {
     required public init(tag: String?) {
         super.init(tag: tag)
     }
 }
 
 /// Row that lets the user choose a suggestion option from a table below the row.
-public final class SuggestionTableRow: _SuggestionRow<SuggestionTableCell<SuggestionTableViewCell>>, RowType {
+public final class SuggestionTableRow<T: SuggestionValue>: _SuggestionRow<T, SuggestionTableCell<T, SuggestionTableViewCell<T>>>, RowType {
     required public init(tag: String?) {
         super.init(tag: tag)
     }

--- a/SuggestionRow/SuggestionTableCell.swift
+++ b/SuggestionRow/SuggestionTableCell.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-public class SuggestionTableCell<TableViewCell: UITableViewCell where TableViewCell: EurekaSuggestionTableViewCell>: SuggestionCell, UITableViewDelegate, UITableViewDataSource {
+public class SuggestionTableCell<T: SuggestionValue, TableViewCell: UITableViewCell where TableViewCell: EurekaSuggestionTableViewCell, TableViewCell.S == T>: SuggestionCell<T>, UITableViewDelegate, UITableViewDataSource {
     
     /// callback that can be used to customize the table cell.
     public var customizeTableViewCell: (TableViewCell -> Void)?
@@ -48,6 +48,11 @@ public class SuggestionTableCell<TableViewCell: UITableViewCell where TableViewC
     override func reload() {
         tableView?.reloadData()
     }
+
+    override func setSuggestions(string: String) {
+        suggestions = (row as? _SuggestionRow<T, SuggestionTableCell>)?.filterFunction(string)
+        reload()
+    }
     
     public override func textFieldDidChange(textField: UITextField) {
         super.textFieldDidChange(textField)
@@ -69,7 +74,7 @@ public class SuggestionTableCell<TableViewCell: UITableViewCell where TableViewC
     public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCellWithIdentifier(cellReuseIdentifier) as! TableViewCell
         if let prediction = suggestions?[indexPath.row] {
-            cell.setTitle(prediction)
+            cell.setupForValue(prediction)
         }
         customizeTableViewCell?(cell)
         return cell

--- a/SuggestionRow/SuggestionTableViewCell.swift
+++ b/SuggestionRow/SuggestionTableViewCell.swift
@@ -9,12 +9,14 @@ import Foundation
 import Eureka
 
 public protocol EurekaSuggestionTableViewCell {
-    func setTitle(prediction: String)
+    associatedtype S: SuggestionValue
+
+    func setupForValue(value: S)
 }
 
 /// Default cell for the table of the SuggestionTableCell
-public class SuggestionTableViewCell: UITableViewCell, EurekaSuggestionTableViewCell {
-    
+public class SuggestionTableViewCell<T: SuggestionValue>: UITableViewCell, EurekaSuggestionTableViewCell {
+    public typealias S = T
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         initialize()
@@ -33,7 +35,7 @@ public class SuggestionTableViewCell: UITableViewCell, EurekaSuggestionTableView
         contentView.backgroundColor = UIColor.whiteColor()
     }
     
-    public func setTitle(prediction: String) {
-        textLabel?.text = prediction
+    public func setupForValue(value: T) {
+        textLabel?.text = value.suggestionString
     }
 }


### PR DESCRIPTION
Also added an example of how this can be used.

The not so beautiful part of this is that we cannot cast to a protocol that has associated types so that having a `SuggestionRowProtocol` brings no real advantage (has been taken out)

Both cells (SuggestionTableCell and SuggestionCollectionCell) have to cast their row to get the filterFunction, but this should not limit overrides. This code must be called from each concrete cell type because casting a concrete SuggestionRow as `_SuggestionRow<T, SuggestionCell<T>>` fails in runtime. (Note the use of the superclass `SuggestionCell`)