### PR TITLE
Asynchronous Filtering

### DIFF
--- a/Sources/SuggestionCollectionCell.swift
+++ b/Sources/SuggestionCollectionCell.swift
@@ -58,8 +58,16 @@ open class SuggestionCollectionCell<T: SuggestionValue, CollectionViewCell: UICo
     }
 
     override func setSuggestions(_ string: String) {
-        suggestions = (row as? _SuggestionRow<SuggestionCollectionCell>)?.filterFunction(string)
-        reload()
+        if let filterFunction = (row as? _SuggestionRow<SuggestionCollectionCell>)?.filterFunction {
+            suggestions = filterFunction(string)
+            reload()
+        }
+        if let asyncFilterFunction = (row as? _SuggestionRow<SuggestionCollectionCell>)?.asyncFilterFunction {
+            asyncFilterFunction(string, { (values) in
+                self.suggestions = values
+                self.reload()
+            })
+        }
     }
     
     //MARK: UICollectionViewDelegate and Datasource

--- a/Sources/SuggestionRow.swift
+++ b/Sources/SuggestionRow.swift
@@ -16,6 +16,7 @@ public protocol SuggestionValue: Equatable, InputTypeInitiable {
 open class _SuggestionRow<Cell: CellType>: FieldRow<Cell> where Cell: BaseCell, Cell: TextFieldCell, Cell.Value: SuggestionValue {
 //SuggestionCell<T>
     public var filterFunction: ((String) -> [Cell.Value])!
+    public var asyncFilterFunction: ((String, (@escaping ([Cell.Value]) -> Void)) -> Void)?
 
     required public init(tag: String?) {
         super.init(tag: tag)

--- a/Sources/SuggestionTableCell.swift
+++ b/Sources/SuggestionTableCell.swift
@@ -54,8 +54,16 @@ open class SuggestionTableCell<T: SuggestionValue, TableViewCell: UITableViewCel
     }
 
     override func setSuggestions(_ string: String) {
-        suggestions = (row as? _SuggestionRow<SuggestionTableCell>)?.filterFunction(string)
-        reload()
+        if let filterFunction = (row as? _SuggestionRow<SuggestionTableCell>)?.filterFunction {
+            suggestions = filterFunction(string)
+            reload()
+        }
+        if let asyncFilterFunction = (row as? _SuggestionRow<SuggestionTableCell>)?.asyncFilterFunction {
+            asyncFilterFunction(string, { (values) in
+                self.suggestions = values
+                self.reload()
+            })
+        }
     }
     
     open override func textFieldDidChange(_ textField: UITextField) {


### PR DESCRIPTION
In our app we needed to be able to make a network request to get autocomplete suggestions. This adds `asyncFilterFunction` with a callback so the suggestions can be updated later. An example of it's use is below. Let me know if you're interested in merging and I'm happy to update the example project. 

Thanks!

```
<<< SuggestionAccessoryRow<Brand>("brandRow") {
  $0.placeholder = ""
  $0.asyncFilterFunction = { (string, filterCompletion) in
      APIClient.search(for: string, withCompletion: { (results, error) in
	filterCompletion(results)
 })
}}
```