### PR TITLE
Fixed a bug & added a config option feature

### DIFF
--- a/Sources/SuggestionRow.swift
+++ b/Sources/SuggestionRow.swift
@@ -17,6 +17,7 @@ open class _SuggestionRow<Cell: CellType>: FieldRow<Cell> where Cell: BaseCell, 
 //SuggestionCell<T>
     public var filterFunction: ((String) -> [Cell.Value])!
     public var asyncFilterFunction: ((String, (@escaping ([Cell.Value]) -> Void)) -> Void)?
+    public var maxSuggestionHeight: CGFloat? // How many row results to show at a time in the view
 
     required public init(tag: String?) {
         super.init(tag: tag)

--- a/Sources/SuggestionRow.swift
+++ b/Sources/SuggestionRow.swift
@@ -17,7 +17,7 @@ open class _SuggestionRow<Cell: CellType>: FieldRow<Cell> where Cell: BaseCell, 
 //SuggestionCell<T>
     public var filterFunction: ((String) -> [Cell.Value])!
     public var asyncFilterFunction: ((String, (@escaping ([Cell.Value]) -> Void)) -> Void)?
-    public var maxSuggestionHeight: Int? // How many row results to show at a time in the view
+    public var maxSuggestionRowHeight: Int? // How many row results to show at a time in the view
 
     required public init(tag: String?) {
         super.init(tag: tag)

--- a/Sources/SuggestionRow.swift
+++ b/Sources/SuggestionRow.swift
@@ -17,7 +17,7 @@ open class _SuggestionRow<Cell: CellType>: FieldRow<Cell> where Cell: BaseCell, 
 //SuggestionCell<T>
     public var filterFunction: ((String) -> [Cell.Value])!
     public var asyncFilterFunction: ((String, (@escaping ([Cell.Value]) -> Void)) -> Void)?
-    public var maxSuggestionRowHeight: Int? // How many row results to show at a time in the view
+    public var maxSuggestionRows: Int? // How many row results to show at a time in the view
 
     required public init(tag: String?) {
         super.init(tag: tag)

--- a/Sources/SuggestionRow.swift
+++ b/Sources/SuggestionRow.swift
@@ -17,7 +17,7 @@ open class _SuggestionRow<Cell: CellType>: FieldRow<Cell> where Cell: BaseCell, 
 //SuggestionCell<T>
     public var filterFunction: ((String) -> [Cell.Value])!
     public var asyncFilterFunction: ((String, (@escaping ([Cell.Value]) -> Void)) -> Void)?
-    public var maxSuggestionHeight: CGFloat? // How many row results to show at a time in the view
+    public var maxSuggestionHeight: Int? // How many row results to show at a time in the view
 
     required public init(tag: String?) {
         super.init(tag: tag)

--- a/Sources/SuggestionTableCell.swift
+++ b/Sources/SuggestionTableCell.swift
@@ -41,8 +41,8 @@ open class SuggestionTableCell<T: SuggestionValue, TableViewCell: UITableViewCel
                 controller.view.addSubview(tableView!)
             }
             let frame = controller.tableView?.convert(self.frame, to: controller.view) ?? self.frame
-            let maxSuggestionHeight = (row as? _SuggestionRow<SuggestionTableCell>)?.maxSuggestionHeight ?? 5
-            tableView?.frame = CGRect(x: 0, y: frame.origin.y + frame.height, width: contentView.frame.width, height: 44 * CGFloat(maxSuggestionHeight))
+            let maxSuggestionRowHeight = (row as? _SuggestionRow<SuggestionTableCell>)?.maxSuggestionRowHeight ?? 5
+            tableView?.frame = CGRect(x: 0, y: frame.origin.y + frame.height, width: contentView.frame.width, height: 44 * CGFloat(maxSuggestionRowHeight))
             tableView?.isHidden = false
         }
     }

--- a/Sources/SuggestionTableCell.swift
+++ b/Sources/SuggestionTableCell.swift
@@ -26,6 +26,7 @@ open class SuggestionTableCell<T: SuggestionValue, TableViewCell: UITableViewCel
     open override func setup() {
         super.setup()
         tableView = UITableView(frame: CGRect.zero, style: .plain)
+        tableView?.tableFooterView = UIView(frame: CGRect.zero)
         tableView?.autoresizingMask = .flexibleHeight
         tableView?.isHidden = true
         tableView?.delegate = self
@@ -40,7 +41,8 @@ open class SuggestionTableCell<T: SuggestionValue, TableViewCell: UITableViewCel
                 controller.view.addSubview(tableView!)
             }
             let frame = controller.tableView?.convert(self.frame, to: controller.view) ?? self.frame
-            tableView?.frame = CGRect(x: 0, y: frame.origin.y + frame.height, width: contentView.frame.width, height: 44*5)
+            let maxSuggestionHeight = (row as? _SuggestionRow<SuggestionTableCell>)?.maxSuggestionHeight ?? 5
+            tableView?.frame = CGRect(x: 0, y: frame.origin.y + frame.height, width: contentView.frame.width, height: 44 * maxSuggestionHeight)
             tableView?.isHidden = false
         }
     }

--- a/Sources/SuggestionTableCell.swift
+++ b/Sources/SuggestionTableCell.swift
@@ -41,7 +41,7 @@ open class SuggestionTableCell<T: SuggestionValue, TableViewCell: UITableViewCel
                 controller.view.addSubview(tableView!)
             }
             let frame = controller.tableView?.convert(self.frame, to: controller.view) ?? self.frame
-            let maxSuggestionRowHeight = (row as? _SuggestionRow<SuggestionTableCell>)?.maxSuggestionRowHeight ?? 5
+            let maxSuggestionRowHeight = (row as? _SuggestionRow<SuggestionTableCell>)?.maxSuggestionRows ?? 5
             tableView?.frame = CGRect(x: 0, y: frame.origin.y + frame.height, width: contentView.frame.width, height: 44 * CGFloat(maxSuggestionRowHeight))
             tableView?.isHidden = false
         }

--- a/Sources/SuggestionTableCell.swift
+++ b/Sources/SuggestionTableCell.swift
@@ -42,7 +42,7 @@ open class SuggestionTableCell<T: SuggestionValue, TableViewCell: UITableViewCel
             }
             let frame = controller.tableView?.convert(self.frame, to: controller.view) ?? self.frame
             let maxSuggestionHeight = (row as? _SuggestionRow<SuggestionTableCell>)?.maxSuggestionHeight ?? 5
-            tableView?.frame = CGRect(x: 0, y: frame.origin.y + frame.height, width: contentView.frame.width, height: 44 * maxSuggestionHeight)
+            tableView?.frame = CGRect(x: 0, y: frame.origin.y + frame.height, width: contentView.frame.width, height: 44 * CGFloat(maxSuggestionHeight))
             tableView?.isHidden = false
         }
     }

--- a/Sources/SuggestionTableViewCell.swift
+++ b/Sources/SuggestionTableViewCell.swift
@@ -31,7 +31,7 @@ open class SuggestionTableViewCell<T: SuggestionValue>: UITableViewCell, EurekaS
         textLabel?.font = .systemFont(ofSize: 16)
         textLabel?.minimumScaleFactor = 0.8
         textLabel?.adjustsFontSizeToFitWidth = true
-        textLabel?.textColor = .blue
+        textLabel?.textColor = .black
         contentView.backgroundColor = .white
     }
     


### PR DESCRIPTION
-Fixed a bug that was causing more rows to show up than search results (if the initial suggestion results were higher but got lower as the user continued typing)
-Added config option maxSuggestionHeight that allows a user to specify how many rows of results they want to show (default is still 5)
-Changed the default color from blue to black since black better matches what native iOS drop down suggestion rows look like